### PR TITLE
Update modman to remove blank line

### DIFF
--- a/modman
+++ b/modman
@@ -1,3 +1,2 @@
 app/code/local/Webtise/CatIndexPositionFix
-
 app/etc/modules/Webtise_CatIndexPositionFix.xml


### PR DESCRIPTION
I can't deploy with composer, as the blank line in the modman file causes composer to error out with "Invalid row on line 0 has 1 parts, expected 2"